### PR TITLE
Disable no-undefined rule in base config

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -315,7 +315,7 @@ const rules = {
   'no-self-compare': 2,
   'no-sequences': 2,
   'no-shadow': 2,
-  'no-shadow-restricted-names': 2,
+  'no-shadow-restricted-names': 2, // Prevent shadowing of NaN, Infinity, undefined, eval, and arguments names.
   'no-spaced-func': 2,
   'no-sparse-arrays': 2,
   'no-tabs': 2,
@@ -326,7 +326,7 @@ const rules = {
   'no-trailing-spaces': 2,
   'no-undef': 2,
   'no-undef-init': 2,
-  'no-undefined': 2,
+  'no-undefined': 0,
   'no-underscore-dangle': [
     2,
     {
@@ -498,6 +498,17 @@ const importRules = {
   ],
 };
 
+
+/* Disable global-require rule in test files. */
+const overrides = [
+  {
+    files: ['**/*.test.js'],
+    rules: {
+      'global-require': 0,
+    },
+  },
+];
+
 module.exports = {
   env: {
     es6: true,
@@ -507,13 +518,5 @@ module.exports = {
   plugins: ['babel', 'import'],
   rules: Object.assign({}, rules, importRules),
   settings: {},
-  overrides: [
-    {
-      files: ['**/*.test.js'],
-      rules: {
-        'no-undefined': 0,
-        'global-require': 0,
-      },
-    },
-  ],
+  overrides,
 };


### PR DESCRIPTION
Updated the base config settings to disable the `no-undefined` rule.

Since ES5, `undefined` has been immutable, so there is no longer a reason to use `void 0` instead.

Additionally the `no-shadow-restricted-names` rule will prevent `undefined` from being used as an argument name in functions.

---

Fixes #15 